### PR TITLE
modified .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ mitou/backend/pose/mmpose/mmpose_cfg/checkpoint/
 mitou/backend/pose/uploads
 mitou/fastapi-env
 mitou/backend/pose/*.pt
-mitou/backend/pose/sample_output
+mitou/backend/pose/sample_output/
 
 backend/pose/MotionAGFormer/checkpoint/
 backend/pose/mmpose/mmpose_cfg/checkpoint/


### PR DESCRIPTION
## WHAT
- `.gitignore`を修正

## WHY
- 無視するディレクトリ名の後ろにバックスラッシュつけ忘れてた