### PR TITLE
Konaka

### DIFF
--- a/mitou/backend/pose/calib/calibration.py
+++ b/mitou/backend/pose/calib/calibration.py
@@ -1,29 +1,41 @@
 import numpy as np
+import asyncio
 
-from .calibfunc import calib_linear
-from .calibfunc import joints2orientations, joints2projections
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
+from .calibfunc import async_calib_linear
+from .calibfunc import async_joints2orientations, async_joints2projections
 from .calibfunc import visible_from_all_cam
 from .preprocess import H36M_BONE
 from .utils import triangulate_with_conf
 
-
-def calibrate(kpts2d_h36m, score2d_h36m, kpts3d, score3d, K):
-    mask_CxNxJ = (score2d_h36m > 0) * (score3d == 1)
-    mask_vis_NxJ = visible_from_all_cam(mask_CxNxJ)
-    vc = joints2orientations(kpts3d, mask_vis_NxJ, H36M_BONE)
-    y = joints2projections(kpts2d_h36m, mask_vis_NxJ)
-
-    n = np.ones((y.shape[0], y.shape[1], 3), dtype=np.float64)
-    n[:, :, :2] = y
+def calculate_n(y, K):
     ni = []
     for i in range(len(K)):
-        ni.append(n[i] @ np.linalg.inv(K[i]).T)
+        ni.append(y[i] @ np.linalg.inv(K[i]).T)
     n = np.array(ni)
+    return n
 
-    R_est, t_est, kpts3d_est = calib_linear(vc, n)
+async def async_calculate_n(executor, y, K):
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(executor, calculate_n, y, K)
+
+async def calibrate(kpts2d_h36m, score2d_h36m, kpts3d, score3d, K):
+    # ThreadPoolExecutorを使用
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        mask_CxNxJ = (score2d_h36m > 0) * (score3d == 1)
+        mask_vis_NxJ = visible_from_all_cam(mask_CxNxJ)
+        vc = await async_joints2orientations(executor, kpts3d, mask_vis_NxJ, H36M_BONE)
+        y = await async_joints2projections(executor, kpts2d_h36m, mask_vis_NxJ)
+        n = np.ones((y.shape[0], y.shape[1], 3), dtype=np.float64)
+        n[:, :, :2] = y
+        n = await async_calculate_n(executor, n, K)
+
+    # 重い処理にはProcessPoolExecutorを使用(将来的にはcalibrateもGPU処理にする)
+    with ProcessPoolExecutor(max_workers=4) as executor:
+        R_est, t_est, kpts3d_est = await async_calib_linear(executor, vc, n)
+
     kpts3d_est = kpts3d_est.reshape(-1, 17, 3)
-
-    kpts3d_tri = triangulate_with_conf(kpts2d_h36m, score2d_h36m,
-                                       K, R_est, t_est, (score2d_h36m > 0))
+    kpts3d_tri = triangulate_with_conf(kpts2d_h36m, score2d_h36m, K, R_est, t_est, (score2d_h36m > 0))
 
     return R_est, t_est, kpts3d_est, kpts3d_tri

--- a/mitou/backend/pose/inference.py
+++ b/mitou/backend/pose/inference.py
@@ -148,6 +148,7 @@ async def inferencer(video_folder, yolo_model, pose_estimator, pose_lifter, devi
     for t in types:
         video_files += glob.glob(video_folder + '/' + t)
     video_files = natsorted(video_files)
+
     print(video_files)
 
     kpts2d, scores2d, kpts3d, scores3d = [], [], [], []
@@ -171,39 +172,6 @@ async def inferencer(video_folder, yolo_model, pose_estimator, pose_lifter, devi
     print("finished 2D&3D")
 
     return kpts2d, scores2d, kpts3d, scores3d
-
-# def inferencer(video_folder, yolo_model, pose_estimator, pose_lifter, device):
-
-#     types = ('*.mp4', '*.mov', '*.avi', '*.MP4', '*.MOV', '*.AVI')
-#     video_files = []
-#     for t in types:
-#         video_files += glob.glob(video_folder + '/' + t)
-#     video_files = natsorted(video_files)
-
-#     print(video_files)
-
-#     kpts2d, scores2d, kpts3d, scores3d = [], [], [], []
-#     for input_video in video_files:
-#         detector = YOLO(yolo_model)
-#         kpt2d, score2d, img_size, bboxs_list = estimate2d(input_video, detector, pose_estimator)
-#         print(kpt2d.shape)
-#         print("estimated2d finished")
-
-#         # モデルサイズに応じてn_framesを変更
-#         kpt3d, score3d = estimate3d(pose_lifter, device, kpt2d, score2d, img_size, n_frames=27)
-#         print("estimated3d finished")
-
-#         kpts2d.append(kpt2d)
-#         scores2d.append(score2d)
-#         kpts3d.append(kpt3d)
-#         scores3d.append(score3d)
-
-#     kpts2d = np.array(kpts2d)
-#     scores2d = np.array(scores2d)
-#     kpts3d = np.array(kpts3d)
-#     scores3d = np.array(scores3d)
-
-#     return kpts2d, scores2d, kpts3d, scores3d
 
 
 async def inferencer_dwp(video_folder, yolo_model, pose_estimator):

--- a/mitou/backend/pose/inference.py
+++ b/mitou/backend/pose/inference.py
@@ -206,7 +206,8 @@ async def inferencer(video_folder, yolo_model, pose_estimator, pose_lifter, devi
 #     return kpts2d, scores2d, kpts3d, scores3d
 
 
-def inferencer_dwp(video_folder, yolo_model, pose_estimator):
+async def inferencer_dwp(video_folder, yolo_model, pose_estimator):
+    executor = ThreadPoolExecutor(max_workers=4)
     types = ('*.mp4', '*.mov', '*.avi', '*.MP4', '*.MOV', '*.AVI')
     video_files = []
     for t in types:
@@ -216,7 +217,7 @@ def inferencer_dwp(video_folder, yolo_model, pose_estimator):
     kpts2d, scores2d = [], []
     for input_video in video_files:
         detector = YOLO(yolo_model)
-        kpt2d, score2d, img_size, _ = estimate2d(input_video, detector,
+        kpt2d, score2d, img_size, _ = await async_estimate2d(executor, input_video, detector,
                                               pose_estimator, wholebody=True)
         # only add 23 keypoints (17 keypoints + 6 foot keypoints)
         kpts2d.append(kpt2d[:, :23, :])

--- a/mitou/backend/pose/movie.py
+++ b/mitou/backend/pose/movie.py
@@ -90,7 +90,8 @@ async def handle_upload(client_id: str, files: List[UploadFile] = File(...)):
         raise HTTPException(status_code=404, detail="WebSocket object not found in connection info")
 
     # 非同期にrun.mainを呼び出し、WebSocketとclient_idを渡す
-    save_path = await run.main(temp_folder_path, websocket, client_id)
+    processor = await run.calibrate_video(temp_folder_path, websocket, client_id)
+    save_path = await run.generate_video(processor)
     print("save_path finished")
 
     return FileResponse(save_path, media_type='video/mp4', filename=Path(save_path).name)

--- a/mitou/backend/pose/movie.py
+++ b/mitou/backend/pose/movie.py
@@ -59,8 +59,9 @@ async def websocket_endpoint(websocket: WebSocket, client_id: str):
             del active_connections[client_id]
         await websocket.close()
 
-@app.post("/upload/{client_id}")
-async def handle_upload(client_id: str, files: List[UploadFile] = File(...)):
+
+@app.post("/calibrate/{client_id}")
+async def calibrate(client_id: str, files: List[UploadFile] = File(...)):
     upload_folder = "uploads"
     temp_folder_path = os.path.join(upload_folder, client_id)
     os.makedirs(temp_folder_path, exist_ok=True)
@@ -68,30 +69,53 @@ async def handle_upload(client_id: str, files: List[UploadFile] = File(...)):
     if client_id not in active_connections:
         active_connections[client_id] = {}
     active_connections[client_id]['temp_folder_path'] = temp_folder_path
-    file_locations = []
 
     try:
         for file in files:
             file_location = os.path.join(temp_folder_path, file.filename)
-            file_locations.append(file_location)
             async with aio_open(file_location, "wb") as file_object:
                 while content := await file.read(1024):
                     await file_object.write(content)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"File upload failed: {e}")
 
-    # WebSocket経由でプログレス更新を送信するためにclient_idを使用
-    connection_info = active_connections.get(client_id)
-    if not connection_info:
-        raise HTTPException(status_code=404, detail="WebSocket connection not found")
+    processor = await run.calibrate_video(temp_folder_path, active_connections[client_id]['websocket'], client_id)
+    active_connections[client_id]['processor'] = processor
+    
+    return {"message": "Calibration started, check WebSocket for progress"}
 
-    websocket = connection_info.get('websocket')
-    if not websocket:
-        raise HTTPException(status_code=404, detail="WebSocket object not found in connection info")
 
-    # 非同期にrun.mainを呼び出し、WebSocketとclient_idを渡す
-    processor = await run.calibrate_video(temp_folder_path, websocket, client_id)
+@app.post("/generate_video/{client_id}")
+async def generate(client_id: str, files: List[UploadFile] = File(...)):
+    if client_id not in active_connections or 'processor' not in active_connections[client_id]:
+        raise HTTPException(status_code=404, detail="Processor not found. Please complete calibration first.")
+
+    processor = active_connections[client_id]['processor']
+
+    # 新しい動画ファイル群を扱うための新しい一時フォルダを作成
+    new_video_folder = os.path.join(active_connections[client_id]['temp_folder_path'], "new_videos")
+    os.makedirs(new_video_folder, exist_ok=True)
+
+    # new_videos フォルダ内の既存ファイルをクリア
+    for filename in os.listdir(new_video_folder):
+        file_path = os.path.join(new_video_folder, filename)
+        try:
+            if os.path.isfile(file_path) or os.path.islink(file_path):
+                os.unlink(file_path)
+            elif os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to delete {filename}: {e}")
+
+    for file in files:
+        new_video_file_path = os.path.join(new_video_folder, file.filename)
+        async with aio_open(new_video_file_path, "wb") as file_object:
+            while content := await file.read(1024):
+                await file_object.write(content)
+
+    # VideoProcessorインスタンスのvideo_folderを新しいフォルダに更新
+    processor.update_video_folder(new_video_folder)
+
     save_path = await run.generate_video(processor)
-    print("save_path finished")
 
     return FileResponse(save_path, media_type='video/mp4', filename=Path(save_path).name)

--- a/mitou/backend/pose/run.py
+++ b/mitou/backend/pose/run.py
@@ -19,71 +19,6 @@ from inference import inferencer, inferencer_dwp
 from MotionAGFormer.model import MotionAGFormer
 from vis.calibpose import vis_calib_res
 
-def load_models(device):
-    pose_config = './mmpose/mmpose_cfg/td-hm_ViTPose-huge_8xb64-210e_coco-256x192.py'
-    pose_ckpt = 'https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_ViTPose-huge_8xb64-210e_coco-256x192-e32adcd4_20230314.pth'
-    pose_estimator = init_model(pose_config, pose_ckpt, device=device)
-
-    dwp_config = './mmpose/mmpose_cfg/rtmpose-l_8xb32-270e_coco-ubody-wholebody-384x288.py'
-    dwp_ckpt = './mmpose/mmpose_cfg/checkpoint/dw-ll_ucoco_384.pth'
-    dwp_estimator = init_model(dwp_config, dwp_ckpt, device=device)
-
-    model_path = "./MotionAGFormer/checkpoint/motionagformer-xs-h36m.pth.tr"
-    if model_path.split('/')[-1].split('-')[1] == 'l':
-        pose_lifter = MotionAGFormer(n_layers=26, dim_in=3, dim_feat=128,
-                                     num_heads=8, neighbour_num=2)
-    elif model_path.split('/')[-1].split('-')[1] == 'b':
-        pose_lifter = MotionAGFormer(n_layers=16, dim_in=3, dim_feat=128,
-                                     num_heads=8, neighbour_num=2)
-    elif model_path.split('/')[-1].split('-')[1] == 'xs':
-        pose_lifter = MotionAGFormer(n_layers=12, dim_in=3, dim_feat=64,
-                                     num_heads=8, neighbour_num=2, n_frames=27)
-    pose_lifter = nn.DataParallel(pose_lifter)
-    pre_dict = torch.load(model_path)
-    pose_lifter.load_state_dict(pre_dict['model'], strict=True)
-    pose_lifter.eval()
-    pose_lifter.to(device)
-
-    return pose_estimator, pose_lifter, dwp_estimator
-
-
-async def main(video_folder, websocket=None, client_id=None):
-    device = "cuda" if torch.cuda.is_available() else "cpu"    
-
-    await send_progress("Loading model", websocket, client_id)
-    yolo_model = 'yolov8x.pt'
-    pose_estimator, pose_lifter, dwp_estimator = load_models(device)
-
-    await send_progress("Estimating 2D & 3D pose", websocket, client_id)
-    kpts2d, scores2d, kpts3d, scores3d = await inferencer(video_folder, yolo_model, pose_estimator,
-                                                    pose_lifter, device)
-
-    await send_progress("Loading camera settings", websocket, client_id)
-    # TODO: カメラデバイスに応じたパラメータ変更を可能にする
-    param_iphone11 = np.load("./intrinsic/iphone11_4K.npz")
-    param_iphone13 = np.load("./intrinsic/iphone13_4K.npz")
-    K = np.array([param_iphone11["mtx"], param_iphone13["mtx"], param_iphone13["mtx"]])
-
-    await send_progress("Processing calibration", websocket, client_id)
-    R_est, t_est, kpts3d_est, kpts3d_tri = calibrate(kpts2d, scores2d, kpts3d, scores3d, K)
-    # Set whole3d to True if you want to visualize the whole body
-    whole3d = True
-    if whole3d:
-        kpts2d_dwp, scores2d_dwp = await inferencer_dwp(video_folder, yolo_model, dwp_estimator)
-        kpts3d_tri = triangulate_with_conf(kpts2d_dwp, scores2d_dwp, 
-                                           K, R_est, t_est, (scores2d_dwp > 0))
-
-    await send_progress("Generating result video", websocket, client_id)
-    save_path = "./sample_output/demodemo.mp4"
-    ani = vis_calib_res(kpts3d_tri, kpts3d, whole3d)
-    ani.save(save_path, writer="ffmpeg")
-    print("save mp4 finished")
-
-    return save_path
-
-
-if __name__ == "__main__":
-    main() 
 
 class VideoProcessor:
     def __init__(self, video_folder, websocket, client_id):
@@ -166,6 +101,10 @@ class VideoProcessor:
         print("save mp4 finished")
 
         return save_path
+    
+    def update_video_folder(self, new_video_folder):
+        self.video_folder = new_video_folder
+        print(f"Video folder updated to: {new_video_folder}")
 
 async def calibrate_video(video_folder, websocket, client_id):
     processor = VideoProcessor(video_folder, websocket, client_id)

--- a/mitou/backend/pose/run.py
+++ b/mitou/backend/pose/run.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn as nn
 import json
 import asyncio
+import os
 from fastapi import WebSocket
 from progress import send_progress
 
@@ -68,7 +69,7 @@ async def main(video_folder, websocket=None, client_id=None):
     # Set whole3d to True if you want to visualize the whole body
     whole3d = True
     if whole3d:
-        kpts2d_dwp, scores2d_dwp = inferencer_dwp(video_folder, yolo_model, dwp_estimator)
+        kpts2d_dwp, scores2d_dwp = await inferencer_dwp(video_folder, yolo_model, dwp_estimator)
         kpts3d_tri = triangulate_with_conf(kpts2d_dwp, scores2d_dwp, 
                                            K, R_est, t_est, (scores2d_dwp > 0))
 
@@ -82,4 +83,98 @@ async def main(video_folder, websocket=None, client_id=None):
 
 
 if __name__ == "__main__":
-    main()
+    main() 
+
+class VideoProcessor:
+    def __init__(self, video_folder, websocket, client_id):
+        self.video_folder = video_folder
+        self.websocket = websocket
+        self.client_id = client_id
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.yolo_model = 'yolov8x.pt'
+        self.pose_estimator = None
+        self.pose_lifter = None
+        self.dwp_estimator = None
+        self.K = None
+        self.R_est = None
+        self.t_est = None
+        self.kpts3d_tri = None
+        self.kpts3d = None
+
+    def load_models(self):
+        pose_config = './mmpose/mmpose_cfg/td-hm_ViTPose-huge_8xb64-210e_coco-256x192.py'
+        pose_ckpt = 'https://download.openmmlab.com/mmpose/v1/body_2d_keypoint/topdown_heatmap/coco/td-hm_ViTPose-huge_8xb64-210e_coco-256x192-e32adcd4_20230314.pth'
+        self.pose_estimator = init_model(pose_config, pose_ckpt, device=self.device)
+
+        dwp_config = './mmpose/mmpose_cfg/rtmpose-l_8xb32-270e_coco-ubody-wholebody-384x288.py'
+        dwp_ckpt = './mmpose/mmpose_cfg/checkpoint/dw-ll_ucoco_384.pth'
+        self.dwp_estimator = init_model(dwp_config, dwp_ckpt, device=self.device)
+
+        model_path = "./MotionAGFormer/checkpoint/motionagformer-xs-h36m.pth.tr"
+        if model_path.split('/')[-1].split('-')[1] == 'l':
+            pose_lifter = MotionAGFormer(n_layers=26, dim_in=3, dim_feat=128,
+                                        num_heads=8, neighbour_num=2)
+        elif model_path.split('/')[-1].split('-')[1] == 'b':
+            pose_lifter = MotionAGFormer(n_layers=16, dim_in=3, dim_feat=128,
+                                        num_heads=8, neighbour_num=2)
+        elif model_path.split('/')[-1].split('-')[1] == 'xs':
+            pose_lifter = MotionAGFormer(n_layers=12, dim_in=3, dim_feat=64,
+                                        num_heads=8, neighbour_num=2, n_frames=27)
+        pose_lifter = nn.DataParallel(pose_lifter)
+        pre_dict = torch.load(model_path)
+        pose_lifter.load_state_dict(pre_dict['model'], strict=True)
+        pose_lifter.eval()
+        pose_lifter.to(self.device)
+        self.pose_lifter = pose_lifter
+    
+    async def init_async(self):
+        await self.send_progress("Loading model")
+        self.load_models()
+    
+    async def send_progress(self, message):
+        if self.websocket and self.client_id:
+            print(f"Sending status '{message}' to client {self.client_id}")
+            await self.websocket.send_json({"client_id": self.client_id, "status": message})
+            await asyncio.sleep(0)  # イベントループにコントロールを戻す
+
+
+    async def process_calibration(self):
+        await self.send_progress("Estimating 2D & 3D pose")
+        kpts2d, scores2d, self.kpts3d, scores3d = await inferencer(self.video_folder, self.yolo_model, self.pose_estimator,
+                                                        self.pose_lifter, self.device)
+
+        await self.send_progress("Loading camera settings")
+        # TODO: カメラデバイスに応じたパラメータ変更を可能にする
+        param_iphone11 = np.load("./intrinsic/iphone11_4K.npz")
+        param_iphone13 = np.load("./intrinsic/iphone13_4K.npz")
+        self.K = np.array([param_iphone11["mtx"], param_iphone13["mtx"], param_iphone13["mtx"]])
+
+        await self.send_progress("Processing calibration")
+        self.R_est, self.t_est, kpts3d_est, self.kpts3d_tri = await calibrate(kpts2d, scores2d, self.kpts3d, scores3d, self.K)
+
+    async def generate_result_video(self):
+        whole3d = True
+        if whole3d:
+            kpts2d_dwp, scores2d_dwp = await inferencer_dwp(self.video_folder, self.yolo_model, self.dwp_estimator)
+            kpts3d_tri =  triangulate_with_conf(kpts2d_dwp, scores2d_dwp, 
+                                            self.K, self.R_est, self.t_est, (scores2d_dwp > 0))
+
+        await self.send_progress("Generating result video")
+        save_path = "./sample_output/demodemo.mp4"
+        ani = vis_calib_res(kpts3d_tri, self.kpts3d, whole3d)
+        ani.save(save_path, writer="ffmpeg")
+        print("save mp4 finished")
+
+        return save_path
+
+async def calibrate_video(video_folder, websocket, client_id):
+    processor = VideoProcessor(video_folder, websocket, client_id)
+    await processor.init_async()
+    await processor.process_calibration()
+    
+    return processor
+
+async def generate_video(processor):
+    save_path = await processor.generate_result_video()
+
+    return save_path

--- a/mitou/fronttest/pages/movie/index.tsx
+++ b/mitou/fronttest/pages/movie/index.tsx
@@ -34,7 +34,7 @@ const IndexPage = () => {
       const heartbeatInterval = setInterval(() => {
         console.log('Sending heartbeat ping');
         websocket.send('ping');
-      }, 15000); // 15秒ごと
+      }, 30000); // 30秒ごと
   
       // Cleanup function for the heartbeat interval
       return () => clearInterval(heartbeatInterval);

--- a/mitou/fronttest/pages/movie/index.tsx
+++ b/mitou/fronttest/pages/movie/index.tsx
@@ -11,13 +11,23 @@ const IndexPage = () => {
   const [ws, setWs] = useState<WebSocket | null>(null);
   const [client_id, setClientId] = useState('');
   const [dots, setDots] = useState('');
+  const [calibrationCompleted, setCalibrationCompleted] = useState(false);
+
 
 
   const fileInputRef = useRef<HTMLInputElement>(null);// ファイル入力要素への参照
+  const generateFileInputRef = useRef<HTMLInputElement>(null); // Generate Video用のファイル入力への参照
+
 
   const handleButtonClick = () => {
     if (fileInputRef.current) {
-      fileInputRef.current.click();// カスタムボタンクリックで実際のファイル入力をトリガー
+      fileInputRef.current.click();// ファイル入力をトリガー
+    }
+  };
+
+  const handleGenerateButtonClick = () => {
+    if (generateFileInputRef.current) {
+      generateFileInputRef.current.click(); // Generate Videoのファイル入力をトリガー
     }
   };
   
@@ -72,36 +82,67 @@ const IndexPage = () => {
       clearInterval(dotsInterval);
     };
   }, []);
-  
-  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+
+  const handleCalibrateFiles = async (event) => {
     if (event.target.files && event.target.files.length > 0) {
-        const formData = new FormData();
-        const uploadedUrls = Array.from(event.target.files).map(file => {
-            formData.append('files', file);
-            return URL.createObjectURL(file); // アップロードされたファイルからURLを生成
+      const formData = new FormData();
+      const uploadedUrls = Array.from(event.target.files).map(file => {
+        formData.append('files', file);
+        return URL.createObjectURL(file); // アップロードされたファイルからURLを生成
+      });
+
+      setUploadedVideos(uploadedUrls); // アップロードされた動画のURLを状態に保存
+      setUploading(true);
+      setCalibrationCompleted(false); 
+
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:8000/calibrate/'}${client_id}`, {
+          method: 'POST',
+          body: formData,
         });
-
-        setUploading(true);
-        setUploadedVideos(uploadedUrls); // アップロードされた動画のURLを状態に保存
-
-        try {
-          const response = await fetch(`${process.env.REACT_APP_UPLOAD_URL || 'http://localhost:8000/upload/'}${client_id}`, {
-            method: 'POST',
-            body: formData,
-          });
-          if (!response.ok) {
-              throw new Error('Network response was not ok');
-          }
-          const blob = await response.blob();
-          const videoUrl = URL.createObjectURL(blob);
-          setVideoSrc(videoUrl); // 処理後の動画URLをセット
-        } catch (error) {
-          console.error('Error uploading the files:', error);
-        } finally {
-          setUploading(false);
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
         }
+        setCalibrationCompleted(true);
+      } catch (error) {
+        console.error('Error uploading the files:', error);
+      } finally {
+        setUploading(false);
+      }
     }
-};
+  };
+
+  const handleGenerateFiles = async (event) => {
+    if (event.target.files && event.target.files.length > 0) {
+      const formData = new FormData();
+      const uploadedUrls = Array.from(event.target.files).map(file => {
+        formData.append('files', file); // 複数のファイルを追加
+        return URL.createObjectURL(file); // アップロードされたファイルからURLを生成
+      });
+  
+      setUploading(true);
+      setUploadedVideos(uploadedUrls);
+      setVideoSrc('');
+  
+      try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL || 'http://localhost:8000/generate_video/'}${client_id}`, {
+          method: 'POST',
+          body: formData,
+        });
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const blob = await response.blob();
+        const videoUrl = URL.createObjectURL(blob);
+        setVideoSrc(videoUrl); // 処理後の動画URLをセット
+      } catch (error) {
+        console.error('Error during video generation:', error);
+      } finally {
+        setUploading(false);
+      }
+    }
+  };
+  
 
 
 return (
@@ -125,40 +166,32 @@ return (
       Upload Videos for Pose Estimation
     </h1>
 
-    {!videoSrc && (
-    <button 
-      onClick={handleButtonClick} 
-      disabled={uploading} 
-      className="customButton"
-      style={{
-        fontSize: '28px', // フォントサイズ
-        padding: '10px 20px', // 内側の余白
-        backgroundColor: '#007bff', // 背景色
-        width: "20%",
-        height: "70px",
-        color: 'white', // 文字色
-        border: 'none', // 境界線を消す
-        borderRadius: '5px', // ボーダーの角を丸くする
-        cursor: uploading ? 'not-allowed' : 'pointer', // カーソルを指定
-        marginTop:"50px",
-        margin: '10px', // 外側の余白
-        // 位置を中央に設定する例
-        display: 'block', // ブロックレベル要素として扱う
-        marginLeft: 'auto', // 自動的に左のマージンを調整
-        marginRight: 'auto', // 自動的に右のマージンを調整
-      }}
-      >
-      {uploading ? 'Uploading...' : 'Select Videos'} {/* アップロード中はボタンのテキストを変更 */}
-    </button>
-    )}
+    <div className="button-container">
+      <input
+        type="file"
+        multiple
+        ref={fileInputRef}
+        onChange={handleCalibrateFiles}
+        style={{ display: 'none' }}
+      />
+      <button className="customButton" onClick={() => fileInputRef.current.click()} disabled={uploading}>
+        Select Videos for Calibration
+      </button>
 
-    <input
-      type="file"
-      multiple
-      ref={fileInputRef}
-      onChange={handleFileChange}
-      style={{ display: 'none' }} // 元のファイル入力は非表示
-    />
+      <input
+        type="file"
+        multiple
+        ref={generateFileInputRef}
+        onChange={handleGenerateFiles}
+        style={{ display: 'none' }}
+        accept="video/*"
+      />
+      <button className="customButton" onClick={handleGenerateButtonClick} disabled={uploading || uploadedVideos.length === 0}>
+        Generate Video
+      </button>
+    </div>
+
+
     {uploading && (
       <div>
         {progressMessage && (
@@ -184,13 +217,18 @@ return (
         )}
       </div>
     )}
+    {calibrationCompleted && (
+      <div style={{ marginTop: '50px', textAlign: 'center', color: 'white'}}>
+        <p>Calibration completed</p>
+      </div>
+    )}
     {videoSrc && ( //現在はDetailsもvideoSrcをトリガーにしている
       <div style={{ marginTop: '40px', marginBottom: '50px', display: 'flex', justifyContent: 'center', alignItems: 'flex-start' }}>
         <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'flex-start', gap: '20px', maxWidth: '1200px', width: '100%' }}> {/* コンテナの最大幅を制限 */}
           {/* 動画コンテナ */}
             <div style={{ textAlign: 'center', flex: 2 }}> {/* 動画コンテナにより多くのスペースを割り当て */}
               <p style={{ fontSize: '50px',color: 'white'}}>Result Video</p>
-              <video controls src={videoSrc} style={{ maxWidth: "720px", width: '100%', height: "auto" }} autoPlay loop>
+              <video controls src={videoSrc} style={{ maxWidth: "720px", width: '100%', height: "auto"}} autoPlay loop>
                 Your browser does not support the video tag.
               </video>
             </div>

--- a/mitou/fronttest/styles/globals.css
+++ b/mitou/fronttest/styles/globals.css
@@ -124,3 +124,10 @@ body {
   background-color: #cccccc;
 }
 
+.button-container {
+  display: flex; 
+  justify-content: center;
+  gap: 20px;
+  margin-top: 20px;
+}
+


### PR DESCRIPTION
## What
- 非同期化されていなかった関数(calibration関数等)の非同期化
- uploadエンドポイントをcalibrateとgenerate_videoエンドポイントに分離
- run.main関数やload_models関数の再利用性を高めるためにクラス定義に変更
- ページ上にcalibrationボタンとgenerate videoボタンを二つ配置
  その他フロント側の微修正

## Why
- タイムアウト対策やプログラムの効率性を高めるため
- キャリブレーションまでとそれ以降の処理を分離するため
- 上記の分離作業において、変数をインスタンス化して再利用する必要があったため
  (変数の中身が保持されるようになり、再度同じ関数を実行する必要がなくなった)
- フロント側で、キャリブレーションを行うための動画と実際に姿勢推定をする動画を
   別でアップロードできるようにするため

## Attention
- main関数をクラス定義にまるごと変更したこと

## Result
- 同じカメラ視点だった場合に、何度も繰り返しキャリブレーションをせずに
  得られたカメラ情報を再利用して処理時間短縮を大幅に短縮できるようになった。